### PR TITLE
Switch to OKX demo trading with order execution

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 
 """
-bot.py — Triple+3 Strategies (Self-Evolving) Scalper — Binance USDM, Alerts-Only
+bot.py — Triple+3 Strategies (Self-Evolving) Scalper — OKX USDT Swap
 (نسخة بدون أي تكامل مع OpenAI — تداول/إشعارات فقط)
 
-تعليمي فقط — لا ينفّذ أوامر تداول حقيقية (Paper Engine).
+تشغيل تجريبي على بيئة الديمو الخاصة بـOKX.
 Env:
-  BINANCE_API_KEY, BINANCE_API_SECRET
+  OKX_API_KEY, OKX_API_SECRET, OKX_API_PASSWORD
   TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
   (اختياري) CRYPTOPANIC_TOKEN, NEWSAPI_KEY  ← تقدر تسيبهم فاضيين
 """
@@ -204,13 +204,16 @@ class Notifier:
 
 class FuturesExchange:
     def __init__(self, cfg: Config):
-        key = os.getenv("BINANCE_API_KEY")
-        secret = os.getenv("BINANCE_API_SECRET")
-        self.x = ccxt.binanceusdm({
-            "apiKey": key, "secret": secret,
-            "options": {"defaultType": "future"},
+        key = os.getenv("OKX_API_KEY")
+        secret = os.getenv("OKX_API_SECRET")
+        password = os.getenv("OKX_API_PASSWORD") or os.getenv("OKX_API_PASSPHRASE")
+        self.x = ccxt.okx({
+            "apiKey": key,
+            "secret": secret,
+            "password": password,
+            "options": {"defaultType": "swap", "demo": True},
             "enableRateLimit": True,
-            "timeout": 15000
+            "timeout": 15000,
         })
         self.x.load_markets()
         self.cfg = cfg
@@ -229,18 +232,24 @@ class FuturesExchange:
 
     def fetch_funding_rate(self, symbol: str) -> Optional[float]:
         try:
-            m = self.x.market(symbol)
-            fr = self.x.fapiPublic_get_premiumindex({"symbol": m["id"]})
-            return safe_float(fr.get("lastFundingRate", None), default=None)
+            fr = self.x.fetch_funding_rate(symbol)
+            return safe_float(fr.get("fundingRate"))
         except Exception:
             return None
 
     def get_balance_usdt(self) -> float:
         try:
-            bal = self.x.fetch_balance(params={"type":"future"})
+            bal = self.x.fetch_balance(params={"type": "swap"})
             return float(bal["total"].get("USDT", 0.0))
         except Exception:
             return 0.0
+
+    def create_demo_order(self, symbol: str, side: str, amount: float):
+        try:
+            return self.x.create_order(symbol, "market", side, amount, None, {"tdMode": "cross"})
+        except Exception as e:
+            print("[WARN] create_order failed:", e)
+            return None
 
     def get_top_symbols(self, n: int = 50) -> List[str]:
         nowt = time.time()
@@ -1187,8 +1196,9 @@ class Bot:
                     f"📏 R:R = {rr if rr is not None else 'n/a'}\n\n"
                     f"🧠 Why: {sig.reason}\n"
                     f"📦 SizeRef: ~{qty_ref:.6f} ({notional_ref:.2f} USDT)\n"
-                    f"⚠️ Alert Only – No Auto Execution"
+                    f"🚀 Executed on OKX Demo"
                 )
+                self.ex.create_demo_order(symbol, sig.side, qty_ref)
                 self.notifier.send(msg)
                 self.last_alert_ts = time.time()
 


### PR DESCRIPTION
## Summary
- replace Binance integration with OKX demo trading
- add real order placement on OKX demo

## Testing
- `python -m py_compile bot.py`
- `python bot.py --timeframe 5m` (fails: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_b_68b85f2e4e7483338820d89268684b23