### PR TITLE
Switch to OKX demo trading with order execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # bot.py
+
+Self-evolving scalper bot for OKX USDT swap markets.
+
+## Features
+
+- Limits concurrent open trades to two.
+- Enforces a minimum position size of 50 USDT.
+- Hourly report with trade summary and net PnL.
+- Daily report listing net profit/loss per symbol.

--- a/bot.py
+++ b/bot.py
@@ -217,6 +217,8 @@ class FuturesExchange:
             "enableRateLimit": True,
             "timeout": 15000,
         })
+        # Force all requests to hit the demo environment
+        self.x.set_sandbox_mode(True)
         # Demo accounts cannot access the private currencies endpoint; disable it
         self.x.has["fetchCurrencies"] = False
         self.x.load_markets()


### PR DESCRIPTION
## Summary
- replace Binance integration with OKX demo trading
- add real order placement on OKX demo
- set `x-simulated-trading` header to ensure OKX demo API keys are accepted and enable OKX's `demo` option
- skip unsupported currency fetch in demo mode
- report order placement failures instead of always claiming execution
- validate that OKX returns a real order ID and specify `posSide` when creating demo orders

## Testing
- `python -m py_compile bot.py`
- `python bot.py --timeframe 5m` *(fails: okx GET https://www.okx.com/api/v5/public/instruments?instType=SPOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b85f2e4e7483338820d89268684b23