### PR TITLE
Add trade limits and periodic PnL reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # bot.py
+
+Self-evolving scalper bot for OKX USDT swap markets.
+
+## Features
+
+- Limits concurrent open trades to two.
+- Enforces a minimum position size of 50 USDT.
+- Hourly report with trade summary and net PnL.
+- Daily report listing net profit/loss per symbol.


### PR DESCRIPTION
## Summary
- limit concurrent open trades to two and enforce minimum 50 USDT position size
- add hourly and daily PnL reporting with per-symbol breakdown

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9a33d2a808333b73ddc5344dd4456